### PR TITLE
feat(datadog): Add DD RUM to flipt-node client

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -4,6 +4,7 @@ README.md
 CHANGELOG.md
 .github
 src/constants.ts
+src/datadogRUM.ts
 LICENSE
 .gitignore
 .release-please-manifest.json

--- a/package.json
+++ b/package.json
@@ -23,13 +23,14 @@
         "prepack": "cp -rv dist/. ."
     },
     "dependencies": {
-        "url-join": "4.0.1",
-        "@types/url-join": "4.0.1",
-        "basic-auth": "2.0.1",
+        "@datadog/browser-rum": "^4.48.1",
         "@types/basic-auth": "1.1.3",
-        "js-base64": "3.7.2",
+        "@types/url-join": "4.0.1",
+        "axios": "0.27.2",
+        "basic-auth": "2.0.1",
         "buffer": "6.0.3",
-        "axios": "0.27.2"
+        "js-base64": "3.7.2",
+        "url-join": "4.0.1"
     },
     "devDependencies": {
         "@types/node": "17.0.33",

--- a/src/datadogRUM.ts
+++ b/src/datadogRUM.ts
@@ -1,0 +1,65 @@
+import { FliptApi } from "@flipt-io/flipt";
+import { datadogRum } from "@datadog/browser-rum";
+
+export interface DatadogRUMOptions {
+    applicationId: string;
+    clientToken: string;
+    site: string;
+    service?: string;
+    env?: string;
+    version?: string;
+    sessionSampleRate?: number;
+    sessionReplaySampleRate?: number;
+    trackResources?: boolean;
+    trackLongTasks?: boolean;
+    trackUserInteractions?: boolean;
+}
+
+export function initializeDatadogRUM(datadogRUMOptions: DatadogRUMOptions) {
+    if (datadogRUMOptions.applicationId === undefined || datadogRUMOptions.applicationId === null) {
+        throw new Error("must define application id");
+    }
+    if (datadogRUMOptions.clientToken === undefined || datadogRUMOptions.clientToken === null) {
+        throw new Error("must define client token");
+    }
+    if (datadogRUMOptions.site === undefined || datadogRUMOptions.site === null) {
+        throw new Error("must define site");
+    }
+
+    datadogRUMOptions.sessionSampleRate = datadogRUMOptions.sessionSampleRate || 100;
+    datadogRUMOptions.sessionReplaySampleRate = datadogRUMOptions.sessionReplaySampleRate || 100;
+    datadogRUMOptions.trackResources = datadogRUMOptions.trackResources || true;
+    datadogRUMOptions.trackLongTasks = datadogRUMOptions.trackLongTasks || true;
+    datadogRUMOptions.trackUserInteractions = datadogRUMOptions.trackUserInteractions || true;
+
+    datadogRum.init(datadogRUMOptions);
+
+    datadogRum.startSessionReplayRecording();
+}
+
+export async function datadogRUMCallback(
+    evaluationCB: (evaluationRequest: FliptApi.evaluation.EvaluationRequest) => any,
+    evaluationRequest: FliptApi.evaluation.EvaluationRequest
+) {
+    // This can result in either a Boolean, or Variant evaluation.
+    const result = await evaluationCB(evaluationRequest);
+
+    // Instrument Datadog RUM metrics after feature flag evaluation.
+    let booleanEvaluationResponse = result as FliptApi.evaluation.BooleanEvaluationResponse;
+    if (booleanEvaluationResponse !== undefined || booleanEvaluationResponse !== null) {
+        datadogRum.addFeatureFlagEvaluation(
+            `${evaluationRequest.namespaceKey}/${evaluationRequest.flagKey}`,
+            booleanEvaluationResponse.enabled
+        );
+        return;
+    }
+
+    let variantEvaluationResponse = result as FliptApi.evaluation.VariantEvaluationResponse;
+    if (variantEvaluationResponse !== undefined || variantEvaluationResponse !== null) {
+        datadogRum.addFeatureFlagEvaluation(
+            `${evaluationRequest.namespaceKey}/${evaluationRequest.flagKey}`,
+            variantEvaluationResponse.variantKey
+        );
+        return;
+    }
+}


### PR DESCRIPTION
This change introduces a client package for [datadog RUM](https://www.datadoghq.com/product/real-user-monitoring/). It essentially wraps evaluation calls (variant, and boolean) with instrumenting DD RUM with feature flags.